### PR TITLE
set user-agent specific for the client

### DIFF
--- a/ohsome/clients.py
+++ b/ohsome/clients.py
@@ -6,7 +6,12 @@ import urllib
 
 import requests
 from ohsome import OhsomeException, OhsomeResponse
-from ohsome.constants import DEFAULT_LOG_DIR, DEFAULT_LOG, OHSOME_BASE_API_URL
+from ohsome.constants import (
+    DEFAULT_LOG_DIR,
+    DEFAULT_LOG,
+    OHSOME_BASE_API_URL,
+    OHSOME_VERSION,
+)
 from ohsome.helper import (
     extract_error_message_from_invalid_json,
     format_boundary,
@@ -19,7 +24,12 @@ from requests.packages.urllib3.util.retry import Retry
 
 class _OhsomeBaseClient:
     def __init__(
-        self, base_api_url=None, log=DEFAULT_LOG, log_dir=DEFAULT_LOG_DIR, cache=None
+        self,
+        base_api_url=None,
+        log=DEFAULT_LOG,
+        log_dir=DEFAULT_LOG_DIR,
+        cache=None,
+        user_agent=None,
     ):
         """
         Initialize _OhsomeInfoClient object
@@ -38,6 +48,10 @@ class _OhsomeBaseClient:
         else:
             self._base_api_url = OHSOME_BASE_API_URL
         self._cache = cache or []
+        if user_agent is not None:
+            self.user_agent = user_agent
+        else:
+            self.user_agent = "ohsome-py/{0}".format(OHSOME_VERSION)
         self.__session = None
 
     def _session(self):
@@ -56,6 +70,7 @@ class _OhsomeBaseClient:
             self.__session = requests.Session()
             self.__session.mount("https://", adapter)
             self.__session.mount("http://", adapter)
+            self.__session.headers["user-agent"] = self.user_agent
         return self.__session
 
     def __repr__(self):
@@ -66,7 +81,12 @@ class _OhsomeInfoClient(_OhsomeBaseClient):
     """Client for metadata of ohsome API"""
 
     def __init__(
-        self, base_api_url=None, log=DEFAULT_LOG, log_dir=DEFAULT_LOG_DIR, cache=None
+        self,
+        base_api_url=None,
+        log=DEFAULT_LOG,
+        log_dir=DEFAULT_LOG_DIR,
+        cache=None,
+        user_agent=None,
     ):
         """
         Initialize _OhsomeInfoClient object
@@ -75,7 +95,9 @@ class _OhsomeInfoClient(_OhsomeBaseClient):
         :param log_dir: Directory for log files, default: ./ohsome_log
         :param cache: Cache for endpoint components
         """
-        super(_OhsomeInfoClient, self).__init__(base_api_url, log, log_dir, cache)
+        super(_OhsomeInfoClient, self).__init__(
+            base_api_url, log, log_dir, cache, user_agent
+        )
         self._parameters = None
         self._metadata = None
         self._url = None
@@ -154,7 +176,12 @@ class _OhsomePostClient(_OhsomeBaseClient):
     """Client for sending requests to ohsome API"""
 
     def __init__(
-        self, base_api_url=None, log=DEFAULT_LOG, log_dir=DEFAULT_LOG_DIR, cache=None
+        self,
+        base_api_url=None,
+        log=DEFAULT_LOG,
+        log_dir=DEFAULT_LOG_DIR,
+        cache=None,
+        user_agent=None,
     ):
         """
         Initialize _OhsomePostClient object
@@ -163,7 +190,9 @@ class _OhsomePostClient(_OhsomeBaseClient):
         :param log_dir: Directory for log files, default: ./ohsome_log
         :param cache: Cache for endpoint components
         """
-        super(_OhsomePostClient, self).__init__(base_api_url, log, log_dir, cache)
+        super(_OhsomePostClient, self).__init__(
+            base_api_url, log, log_dir, cache, user_agent
+        )
         self._parameters = None
         self._metadata = None
         self._url = None

--- a/ohsome/constants.py
+++ b/ohsome/constants.py
@@ -6,4 +6,4 @@ OHSOME_BASE_API_URL = "https://api.ohsome.org/v1/"
 DEFAULT_LOG = True
 DEFAULT_LOG_DIR = "./ohsome_log"
 # update version in pyproject.toml as well
-OHSOME_VERSION = "0.1.0rc1"
+OHSOME_VERSION = "0.1.0rc2"

--- a/ohsome/constants.py
+++ b/ohsome/constants.py
@@ -5,3 +5,5 @@
 OHSOME_BASE_API_URL = "https://api.ohsome.org/v1/"
 DEFAULT_LOG = True
 DEFAULT_LOG_DIR = "./ohsome_log"
+# update version in pyproject.toml as well
+OHSOME_VERSION = "0.1.0rc1"

--- a/ohsome/test/test_client.py
+++ b/ohsome/test/test_client.py
@@ -11,6 +11,7 @@ import pandas as pd
 import pytest
 
 import ohsome
+from ohsome.constants import OHSOME_VERSION
 
 script_path = os.path.dirname(os.path.realpath(__file__))
 logger = logging.getLogger(__name__)
@@ -56,6 +57,19 @@ def test_api_version(custom_client):
     :return:
     """
     assert isinstance(custom_client.api_version, str)
+
+
+def test_user_agent(custom_client):
+    """
+    Checks user agent set by ohsome-py
+    :return:
+    """
+    client = custom_client
+    resp = client._session().get(client._url)
+    print(resp.request.headers)
+    used_user_agent = resp.request.headers["user-agent"].split("/")
+    assert used_user_agent[0] == "ohsome-py"
+    assert used_user_agent[1] == OHSOME_VERSION
 
 
 def test_check_time_parameter_list(custom_client):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,6 @@
 [tool.poetry]
 name = "ohsome"
+# update version in ohsome/constants.py as well
 version = "0.1.0rc1"
 description = "A Python client for the ohsome API"
 authors = ["Christina Ludwig <christina.ludwig@uni-heidelberg.de>"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "ohsome"
 # update version in ohsome/constants.py as well
-version = "0.1.0rc1"
+version = "0.1.0rc2"
 description = "A Python client for the ohsome API"
 authors = ["Christina Ludwig <christina.ludwig@uni-heidelberg.de>"]
 readme = 'README.md'


### PR DESCRIPTION
closes #72

* sets the user agent to a ohsome-py specific version
* with this solution the version has to be updated at two places, but this solution has the advantage that the client doesn't have to parse the toml file manually